### PR TITLE
Add `qubes-usb-proxy` as requirement for sys-usb

### DIFF
--- a/user/managing-os/minimal-templates.md
+++ b/user/managing-os/minimal-templates.md
@@ -92,7 +92,7 @@ As usual, the required packages are to be installed in the running template with
  - NetVM, such as the template for `sys-net`: `qubes-core-agent-networking` `qubes-core-agent-network-manager` `NetworkManager-wifi` `network-manager-applet` `wireless-tools` `notification-daemon` `gnome-keyring` `polkit` `@hardware-support`.
    If your network devices need extra packages for the template to work as a network VM, use the `lspci` command to identify the devices, then run `dnf search firmware` (replace `firmware` with the appropriate device identifier) to find the needed packages and then install them.
    If you need utilities for debugging and analyzing network connections, install `tcpdump` `telnet` `nmap` `nmap-ncat`.
- - [USB qube](/doc/usb-qubes/), such as the template for `sys-usb`: `qubes-input-proxy-sender`.
+ - [USB qube](/doc/usb-qubes/), such as the template for `sys-usb`: `qubes-input-proxy-sender` and `qubes-usb-proxy`.
  - [VPN qube](/doc/vpn/): Use the `dnf search "NetworkManager VPN plugin"` command to look up the VPN packages you need, based on the VPN technology you'll be using, and install them.
    Some GNOME related packages may be needed as well.
    After creation of a machine based on this template, follow the [VPN instructions](/doc/vpn/#set-up-a-proxyvm-as-a-vpn-gateway-using-networkmanager) to configure it.


### PR DESCRIPTION
When using a minimal template based sys-usb, `qubes-usb-proxy` appears to be an actual requirement, otherwise USB devices fail to attach. I'm not sure if this is also a bug (i.e., package `qubes-input-proxy-sender` should depend on `qubes-usb-proxy`), but it's definitely a documentation issue. I will probably open a separate qubes-issue for the dependency.